### PR TITLE
Update workflows and BSP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
       JETSON_NANO_BOARD: ${{ matrix.board }}
       JETSON_NANO_REVISION: ${{ matrix.revision }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Build docker image
         run: docker buildx build --platform linux/arm64 -t jetson-nano-image .
@@ -43,7 +43,7 @@ jobs:
           sudo -E ./create-image.sh
 
       - name: Upload image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.board }}-r${{ matrix.revision }}
           path: |

--- a/create-image.sh
+++ b/create-image.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-BSP=https://developer.nvidia.com/embedded/l4t/r32_release_v6.1/t210/jetson-210_linux_r32.6.1_aarch64.tbz2
+BSP=https://developer.nvidia.com/downloads/remetpack-463r32releasev73t210jetson-210linur3273aarch64tbz2
 
 # Check if the user is not root
 if [ "x$(whoami)" != "xroot" ]; then

--- a/root/etc/apt/sources.list.d/nvidia-l4t.list
+++ b/root/etc/apt/sources.list.d/nvidia-l4t.list
@@ -1,2 +1,2 @@
-deb [signed-by=/usr/share/keyrings/nvidia-l4t-archive-keyring.asc] https://repo.download.nvidia.com/jetson/common r32.6 main
-deb [signed-by=/usr/share/keyrings/nvidia-l4t-archive-keyring.asc] https://repo.download.nvidia.com/jetson/t210 r32.6 main
+deb [signed-by=/usr/share/keyrings/nvidia-l4t-archive-keyring.asc] https://repo.download.nvidia.com/jetson/common r32.7 main
+deb [signed-by=/usr/share/keyrings/nvidia-l4t-archive-keyring.asc] https://repo.download.nvidia.com/jetson/t210 r32.7 main


### PR DESCRIPTION
- Update legacy work flow to Node.js 16 (Node.js 12 will be deprecated this month)
- Update BSP and nvidia-repo to latest version (last jetpack for Jetson Nano)

I already test the image and it run smooth so far. Bug in BSP regarding rootfs doesn't exist on this build.
There is still bug in /etc/resolv.conf thought.
It can be mitigate with [this](https://github.com/pythops/jetson-nano-image/issues/92)